### PR TITLE
Get checks back from experiment

### DIFF
--- a/cornflow_client/airflow/dag_utilities.py
+++ b/cornflow_client/airflow/dag_utilities.py
@@ -116,6 +116,17 @@ def try_to_write_solution(client, exec_id, payload):
         # attempt to update the execution with a failed status.
         raise AirflowDagException("The writing of the solution failed")
 
+    if payload["inst_checks"]:
+        checks_payload = dict()
+        checks_payload["checks"] = payload["inst_checks"]
+        try:
+            client.write_instance_checks(
+                instance_id=payload["inst_id"], **checks_payload
+            )
+        except CornFlowApiError:
+            try_to_save_error(client, exec_id, -6)
+            raise AirflowDagException("The writing of the instance checks failed")
+
 
 def get_schema(dag_name):
     _file = os.path.join(os.path.dirname(__file__), "{}_output.json".format(dag_name))
@@ -142,8 +153,9 @@ def cf_solve(fun, dag_name, secrets, **kwargs):
     execution_data = client.get_data(exec_id)
     data = execution_data["data"]
     config = execution_data["config"]
+    inst_id = execution_data["id"]
     try:
-        solution, checks, log, log_json = fun(data, config)
+        solution, sol_checks, inst_checks, log, log_json = fun(data, config)
     except NoSolverException as e:
         if config.get("msg", True):
             print("No solver found !")
@@ -154,7 +166,16 @@ def cf_solve(fun, dag_name, secrets, **kwargs):
             print("Some unknown error happened")
         try_to_save_error(client, exec_id, -1)
         raise AirflowDagException("There was an error during the solving")
-    payload = dict(state=1, log_json=log_json, log_text=log, solution_schema=dag_name)
+
+    payload = dict(
+        state=1,
+        log_json=log_json,
+        log_text=log,
+        solution_schema=dag_name,
+        inst_checks=inst_checks,
+        inst_id=inst_id,
+    )
+
     if not solution:
         # No solution found: we just send everything to cornflow.
         if config.get("msg", True):
@@ -166,11 +187,12 @@ def cf_solve(fun, dag_name, secrets, **kwargs):
     # If it's not: we change the status to Invalid
     # and take out the server validation of the schema\
     payload["data"] = solution
+
     if config.get("msg", True):
         print("A solution was found: we will first validate it")
 
-    if checks is not None:
-        payload["checks"] = checks
+    if sol_checks is not None:
+        payload["checks"] = sol_checks
 
     try_to_write_solution(client, exec_id, payload)
 

--- a/cornflow_client/airflow/dag_utilities.py
+++ b/cornflow_client/airflow/dag_utilities.py
@@ -109,8 +109,11 @@ def try_to_write_solution(client, exec_id, payload):
     If it fails tries to write again that it failed.
     If it fails at least once: it raises an exception
     """
+    execution_payload = dict(**payload)
+    execution_payload.pop("inst_id")
+    execution_payload.pop("inst_checks")
     try:
-        client.write_solution(execution_id=exec_id, **payload)
+        client.write_solution(execution_id=exec_id, **execution_payload)
     except CornFlowApiError:
         try_to_save_error(client, exec_id, -6)
         # attempt to update the execution with a failed status.

--- a/cornflow_client/airflow/dag_utilities.py
+++ b/cornflow_client/airflow/dag_utilities.py
@@ -143,7 +143,7 @@ def cf_solve(fun, dag_name, secrets, **kwargs):
     data = execution_data["data"]
     config = execution_data["config"]
     try:
-        solution, log, log_json = fun(data, config)
+        solution, checks, log, log_json = fun(data, config)
     except NoSolverException as e:
         if config.get("msg", True):
             print("No solver found !")
@@ -168,6 +168,9 @@ def cf_solve(fun, dag_name, secrets, **kwargs):
     payload["data"] = solution
     if config.get("msg", True):
         print("A solution was found: we will first validate it")
+
+    if checks is not None:
+        payload["checks"] = checks
 
     try_to_write_solution(client, exec_id, payload)
 

--- a/cornflow_client/core/application.py
+++ b/cornflow_client/core/application.py
@@ -187,7 +187,10 @@ class ApplicationCore(ABC):
 
         if log["sol_code"] > 0:
             sol = algo.solution.to_dict()
-        return sol, "", log
+
+        checks = algo.check_solution()
+
+        return sol, checks, "", log
 
     def get_solver(self, name: str = "default") -> Union[Type[ExperimentCore], None]:
         """

--- a/cornflow_client/core/application.py
+++ b/cornflow_client/core/application.py
@@ -107,12 +107,12 @@ class ApplicationCore(ABC):
 
     def solve(
         self, data: dict, config: dict, solution_data: dict = None
-    ) -> Tuple[Dict, str, Dict]:
+    ) -> Tuple[Dict, Union[Dict, None], str, Dict]:
         """
         :param data: json for the problem
         :param config: execution configuration, including solver
         :param solution_data: optional json with an initial solution
-        :return: solution and log
+        :return: solution, checks and log
         """
         if config.get("msg", True):
             print("Solving the model")
@@ -152,7 +152,7 @@ class ApplicationCore(ABC):
                 status_code=STATUS_INFEASIBLE,
                 sol_code=SOLUTION_STATUS_INFEASIBLE,
             )
-            return dict(), "", log
+            return dict(), None, "", log
 
         algo = solver_class(inst, sol)
         start = timer()

--- a/cornflow_client/core/application.py
+++ b/cornflow_client/core/application.py
@@ -107,12 +107,12 @@ class ApplicationCore(ABC):
 
     def solve(
         self, data: dict, config: dict, solution_data: dict = None
-    ) -> Tuple[Dict, Union[Dict, None], str, Dict]:
+    ) -> Tuple[Dict, Union[Dict, None], Union[Dict, None], str, Dict]:
         """
         :param data: json for the problem
         :param config: execution configuration, including solver
         :param solution_data: optional json with an initial solution
-        :return: solution, checks and log
+        :return: solution, solution checks, instance checks and logs
         """
         if config.get("msg", True):
             print("Solving the model")
@@ -144,7 +144,8 @@ class ApplicationCore(ABC):
                     "The solution does not match the schema:\n{}".format(sol_errors)
                 )
 
-        if inst.check():
+        instance_checks = inst.check()
+        if instance_checks:
             log = dict(
                 time=0,
                 solver=solver,
@@ -152,7 +153,7 @@ class ApplicationCore(ABC):
                 status_code=STATUS_INFEASIBLE,
                 sol_code=SOLUTION_STATUS_INFEASIBLE,
             )
-            return dict(), None, "", log
+            return dict(), None, instance_checks, "", log
 
         algo = solver_class(inst, sol)
         start = timer()
@@ -190,7 +191,7 @@ class ApplicationCore(ABC):
 
         checks = algo.check_solution()
 
-        return sol, checks, "", log
+        return sol, checks, {}, "", log
 
     def get_solver(self, name: str = "default") -> Union[Type[ExperimentCore], None]:
         """

--- a/cornflow_client/core/instance.py
+++ b/cornflow_client/core/instance.py
@@ -2,7 +2,7 @@
 
 """
 # Partial imports
-from abc import ABC, abstractmethod
+from abc import ABC
 
 # Imports from internal modules
 from .instance_solution import InstanceSolutionCore
@@ -13,22 +13,25 @@ class InstanceCore(InstanceSolutionCore, ABC):
     The instance template.
     """
 
+    # TODO: make abstractmethod
     def check_inconsistencies(self, *args, **kwargs) -> dict:
         """
         Method that checks if there are inconsistencies in the data of the current instance.
 
         :return: A dictionary containing the inconsistencies found.
         """
-        pass
+        return dict()
 
+    # TODO: make abstractmethod
     def check_feasibility(self, *args, **kwargs) -> bool:
         """
         Method that checks if the problem is feasible.
 
         :return: True if the problem is feasible, False otherwise
         """
-        pass
+        return True
 
+    # TODO: make abstractmethod
     def check(self, *args, **kwargs) -> dict:
         """
         Method that checks if there are inconsistencies in the data of the instance and if the problem is feasible

--- a/cornflow_client/core/instance.py
+++ b/cornflow_client/core/instance.py
@@ -2,7 +2,7 @@
 
 """
 # Partial imports
-from abc import ABC
+from abc import ABC, abstractmethod
 
 # Imports from internal modules
 from .instance_solution import InstanceSolutionCore
@@ -19,7 +19,7 @@ class InstanceCore(InstanceSolutionCore, ABC):
 
         :return: A dictionary containing the inconsistencies found.
         """
-        return dict()
+        pass
 
     def check_feasibility(self, *args, **kwargs) -> bool:
         """
@@ -27,7 +27,7 @@ class InstanceCore(InstanceSolutionCore, ABC):
 
         :return: True if the problem is feasible, False otherwise
         """
-        return True
+        pass
 
     def check(self, *args, **kwargs) -> dict:
         """

--- a/cornflow_client/cornflow_client.py
+++ b/cornflow_client/cornflow_client.py
@@ -84,7 +84,7 @@ class CornFlow(object):
                 "Authorization": "access_token " + self.token,
                 "Content-Encoding": encoding,
             },
-            **kwargs
+            **kwargs,
         )
 
     def get_api(self, api, method="GET", encoding=None, **kwargs):
@@ -95,7 +95,7 @@ class CornFlow(object):
                 "Authorization": "access_token " + self.token,
                 "Content-Encoding": encoding,
             },
-            **kwargs
+            **kwargs,
         )
 
     @ask_token
@@ -136,7 +136,7 @@ class CornFlow(object):
         api_for_id with a PATCH request
         """
         return self.api_for_id(
-            api=api, id=id, json=payload, method="patch", encoding=encoding ** kwargs
+            api=api, id=id, json=payload, method="patch", encoding=encoding**kwargs
         )
 
     @ask_token
@@ -158,7 +158,7 @@ class CornFlow(object):
                 "Authorization": "access_token " + self.token,
                 "Content-Encoding": encoding,
             },
-            **kwargs
+            **kwargs,
         )
 
     @log_call
@@ -396,6 +396,19 @@ class CornFlow(object):
                 "Expected a code 200, got a {} error instead: {}".format(
                     response.status_code, response.text
                 )
+            )
+        return response.json()
+
+    @ask_token
+    @prepare_encoding
+    def write_instance_checks(self, instance_id, encoding=None, **kwargs):
+        """"""
+        response = self.put_api_for_id(
+            "instance/", id=instance_id, encoding=encoding, payload=kwargs
+        )
+        if response.status_code != 200:
+            raise CornFlowApiError(
+                f"Expected a 200, got a {response.status_code} error instead: {response.text}"
             )
         return response.json()
 

--- a/cornflow_client/cornflow_client.py
+++ b/cornflow_client/cornflow_client.py
@@ -136,7 +136,7 @@ class CornFlow(object):
         api_for_id with a PATCH request
         """
         return self.api_for_id(
-            api=api, id=id, json=payload, method="patch", encoding=encoding**kwargs
+            api=api, id=id, json=payload, method="patch", encoding=encoding, **kwargs
         )
 
     @ask_token

--- a/cornflow_client/cornflow_client.py
+++ b/cornflow_client/cornflow_client.py
@@ -404,7 +404,7 @@ class CornFlow(object):
     def write_instance_checks(self, instance_id, encoding=None, **kwargs):
         """"""
         response = self.put_api_for_id(
-            "instance/", id=instance_id, encoding=encoding, payload=kwargs
+            "dag/instance/", id=instance_id, encoding=encoding, payload=kwargs
         )
         if response.status_code != 200:
             raise CornFlowApiError(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extra_required = {"excel": ["openpyxl"]}
 
 setuptools.setup(
     name="cornflow-client",
-    version="0.31.0",
+    version="0.32.0",
     author="baobab soluciones",
     author_email="sistemas@baobabsoluciones.es",
     description="Client to connect to a cornflow server",


### PR DESCRIPTION
The checks that get performed on the check_solution method that has to be implemented on all solvers (or in the base experiment) get sent back to be stored on the executions table so it can be given back to the user when querying back for the results of the execution.